### PR TITLE
CLI Options and App Config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,11 @@ xxhash-rust = { version = "0.8.2", features = ["xxh3"]}
 tokio = { version = "1.6.1", features = ["full"] }
 poldercast = "1.2.0"
 sled = "0.34.6"
+clap = "3.0.0-beta.2"
+
+[[bin]]
+name = "estanley"
+path = "src/main.rs"
 
 [profile.release]
 lto = true

--- a/appsettings.toml
+++ b/appsettings.toml
@@ -1,0 +1,8 @@
+debug = "false"
+quiet = "false"
+
+[data]
+path = "data/"
+
+[peers]
+source = "placeholder_value"

--- a/appsettings.toml
+++ b/appsettings.toml
@@ -1,6 +1,3 @@
-debug = "false"
-quiet = "false"
-
 [data]
 path = "data/"
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,2 +1,0 @@
-pub data_path: data/
-pub peer_discovery_src: placeholder_value

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,22 @@
+use clap::Clap;
+
+/// A Dummy Application to work with Estella
+#[derive(Clap)]
+#[clap(name = "Estella")]
+pub struct Opts {
+    /// Include Debug level logs. Overrides Quiet
+    #[clap(short, long)]
+    pub debug: bool,
+
+    /// Exclude all logs below Error. Overridden by Debug
+    #[clap(short, long)]
+    pub quiet: bool,
+
+    /// Path to datastore
+    #[clap(long)]
+    pub data_path: Option<String>,
+
+    /// Source to discover peers
+    #[clap(long)]
+    pub peer_src: Option<String>,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,4 @@
-use anyhow;
 use clap::Clap;
-use log;
 use simplelog::{Config, LevelFilter, TermLogger, TerminalMode};
 
 mod cli;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,37 @@
 use anyhow;
+use clap::Clap;
 use log;
 use simplelog::{Config, LevelFilter, TermLogger, TerminalMode};
 
+mod cli;
 mod settings;
 use settings::Settings;
 
+use crate::cli::Opts;
+
 fn main() -> anyhow::Result<()> {
+    let opts = Opts::parse();
+    let setings = Settings::new(opts)?;
+
     TermLogger::init(
-        LevelFilter::Debug,
+        log_level(&setings),
         Config::default(),
         TerminalMode::Mixed,
         simplelog::ColorChoice::Always,
     )?;
     log::info!("Starting up...");
-    Settings::new()?;
-    log::info!("Setup Config");
+
+    log::info!("Setup Config {:#?}", setings);
+
     Ok(())
+}
+
+fn log_level(settings: &Settings) -> LevelFilter {
+    if settings.debug {
+        LevelFilter::Debug
+    } else if settings.quiet {
+        LevelFilter::Error
+    } else {
+        LevelFilter::Info
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,25 +9,24 @@ use crate::cli::Opts;
 
 fn main() -> anyhow::Result<()> {
     let opts = Opts::parse();
-    let setings = Settings::new(opts)?;
-
     TermLogger::init(
-        log_level(&setings),
+        log_level(&opts),
         Config::default(),
         TerminalMode::Mixed,
         simplelog::ColorChoice::Always,
     )?;
     log::info!("Starting up...");
 
+    let setings = Settings::new(opts)?;
     log::info!("Setup Config {:#?}", setings);
 
     Ok(())
 }
 
-fn log_level(settings: &Settings) -> LevelFilter {
-    if settings.debug {
+fn log_level(opts: &Opts) -> LevelFilter {
+    if opts.debug {
         LevelFilter::Debug
-    } else if settings.quiet {
+    } else if opts.quiet {
         LevelFilter::Error
     } else {
         LevelFilter::Info

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,20 +1,65 @@
+use crate::cli::Opts;
 use config::{Config, ConfigError, Environment, File};
 use serde::Deserialize;
 use std::env;
 
 #[derive(Debug, Deserialize)]
+pub struct Peers {
+    /// later a list of urls or ips that the application can use to discover peers
+    pub source: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Data {
+    /// Local path for sled data store
+    pub path: String,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct Settings {
-    pub data_path: String,          // Local path for sled data store
-    pub peer_discovery_src: String, // later a list of urls or ips that the application can use to discover peers
+    pub debug: bool,
+    pub quiet: bool,
+    pub data: Data,
+    pub peers: Peers,
 }
 
 impl Settings {
-    pub fn new() -> Result<Self, ConfigError> {
+    pub fn new(opts: Opts) -> Result<Self, ConfigError> {
         let mut s = Config::new();
-        s.merge(File::with_name("config.yaml"))?;
+
+        // Config File
+        s.merge(File::with_name("appsettings"))?;
+
+        // Development Environment Overrides
         let env = env::var("RUN_MODE").unwrap_or_else(|_| "development".into());
-        s.merge(File::with_name(&format!("config/{}", env)).required(false))?;
-        s.merge(Environment::with_prefix("app"))?;
+        s.merge(File::with_name(&format!("config/appsettings.{}", env)).required(false))?;
+
+        // Environment Variables
+        s.merge(Environment::with_prefix("app").separator("_"))?;
+
+        // CLI Opts
+        include_cli_opts(&mut s, opts)?;
+
         s.try_into()
     }
+}
+
+fn include_cli_opts(s: &mut Config, opts: Opts) -> Result<(), ConfigError> {
+    if opts.debug {
+        s.set("debug", true)?;
+    }
+
+    if opts.quiet {
+        s.set("quiet", true)?;
+    }
+
+    if let Some(d) = opts.data_path {
+        s.set("data.path", d)?;
+    }
+
+    if let Some(p) = opts.peer_src {
+        s.set("peers.source", p)?;
+    }
+
+    Ok(())
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -17,8 +17,6 @@ pub struct Data {
 
 #[derive(Debug, Deserialize)]
 pub struct Settings {
-    pub debug: bool,
-    pub quiet: bool,
     pub data: Data,
     pub peers: Peers,
 }
@@ -45,14 +43,6 @@ impl Settings {
 }
 
 fn include_cli_opts(s: &mut Config, opts: Opts) -> Result<(), ConfigError> {
-    if opts.debug {
-        s.set("debug", true)?;
-    }
-
-    if opts.quiet {
-        s.set("quiet", true)?;
-    }
-
     if let Some(d) = opts.data_path {
         s.set("data.path", d)?;
     }


### PR DESCRIPTION
# Task
Add a CLI for Estanley with options that can be provided to override config

All config can currently be set via the following, with each step overriding the next

1. `appsettings.toml` - Default App Settings
```
[data]
path = "data/"

[peers]
source = "placeholder_value"
```
![Screen Shot 2021-06-26 at 5 45 29 pm](https://user-images.githubusercontent.com/926668/123506268-a79e0b80-d6a6-11eb-9376-e367fd3353ba.png)

2. `config/appsettings.${ENV}.toml` - Same as `appsettings.toml` but app env override.
Will look for file with ENV specified by `RUN_MODE` env var
    *  Will use `config/appsettings.development.toml` by default if file is present and no `RUN_MODE` var is set

3.  Environment variables starting with `APP_`
![Screen Shot 2021-06-26 at 5 47 20 pm](https://user-images.githubusercontent.com/926668/123506276-b389cd80-d6a6-11eb-9c37-f8730fadbed9.png)

4. CLI Options provided at runtime
![Screen Shot 2021-06-26 at 5 46 17 pm](https://user-images.githubusercontent.com/926668/123506290-c0a6bc80-d6a6-11eb-871f-97a7fdb8f6f0.png)
